### PR TITLE
feat: add API response types and error handling utilities

### DIFF
--- a/types/server/api-response.ts
+++ b/types/server/api-response.ts
@@ -1,0 +1,35 @@
+export type ApiErrorPayload = {
+  message: string
+  code?: string
+  details?: unknown
+}
+
+export type ApiSuccessResponse<T> = {
+  success: true
+  data: T
+}
+
+export type ApiErrorResponse = {
+  success: false
+  error: ApiErrorPayload
+}
+
+export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse
+
+export const buildSuccessResponse = <T>(data: T): ApiSuccessResponse<T> => ({
+  success: true,
+  data
+})
+
+export const buildErrorResponse = (
+  message: string,
+  code?: string,
+  details?: unknown
+): ApiErrorResponse => ({
+  success: false,
+  error: {
+    message,
+    ...(code ? { code } : {}),
+    ...(details !== undefined ? { details } : {})
+  }
+})

--- a/types/server/error-handler.ts
+++ b/types/server/error-handler.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+
+import { buildErrorResponse } from './api-response'
+import { ApiError, InternalServerError } from './errors'
+
+export const toApiError = (error: unknown): ApiError => {
+  if (error instanceof ApiError) {
+    return error
+  }
+
+  if (error instanceof Error) {
+    return new InternalServerError(error.message, { cause: error })
+  }
+
+  return new InternalServerError('Unexpected error')
+}
+
+export const handleApiError = (error: unknown): NextResponse => {
+  const apiError = toApiError(error)
+  const responseBody = buildErrorResponse(
+    apiError.message,
+    apiError.code,
+    apiError.details
+  )
+
+  return NextResponse.json(responseBody, { status: apiError.statusCode })
+}
+
+type RouteHandler<TResponse extends Response = Response> = (
+  ...args: unknown[]
+) => Promise<TResponse>
+
+export const withErrorHandling = <TResponse extends Response>(
+  handler: RouteHandler<TResponse>
+) => {
+  return async (...args: Parameters<RouteHandler<TResponse>>) => {
+    try {
+      return await handler(...args)
+    } catch (error) {
+      return handleApiError(error)
+    }
+  }
+}

--- a/types/server/errors.ts
+++ b/types/server/errors.ts
@@ -1,0 +1,77 @@
+export type ApiErrorOptions = {
+  statusCode: number
+  code: string
+  details?: unknown
+  cause?: unknown
+}
+
+export class ApiError extends Error {
+  public readonly statusCode: number
+  public readonly code: string
+  public readonly details?: unknown
+  public readonly cause?: unknown
+
+  constructor(message: string, options: ApiErrorOptions) {
+    super(message)
+    this.name = new.target.name
+    this.statusCode = options.statusCode
+    this.code = options.code
+    this.details = options.details
+    this.cause = options.cause
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+
+export class ValidationError extends ApiError {
+  constructor(message = 'Validation error', details?: unknown) {
+    super(message, {
+      statusCode: 400,
+      code: 'VALIDATION_ERROR',
+      details
+    })
+  }
+}
+
+export class AuthenticationError extends ApiError {
+  constructor(message = 'Authentication required', details?: unknown) {
+    super(message, {
+      statusCode: 401,
+      code: 'AUTHENTICATION_ERROR',
+      details
+    })
+  }
+}
+
+export class AuthorizationError extends ApiError {
+  constructor(message = 'Not authorized', details?: unknown) {
+    super(message, {
+      statusCode: 403,
+      code: 'AUTHORIZATION_ERROR',
+      details
+    })
+  }
+}
+
+export class NotFoundError extends ApiError {
+  constructor(message = 'Resource not found', details?: unknown) {
+    super(message, {
+      statusCode: 404,
+      code: 'NOT_FOUND',
+      details
+    })
+  }
+}
+
+export class InternalServerError extends ApiError {
+  constructor(
+    message = 'Internal server error',
+    options?: { details?: unknown; cause?: unknown }
+  ) {
+    super(message, {
+      statusCode: 500,
+      code: 'INTERNAL_SERVER_ERROR',
+      details: options?.details,
+      cause: options?.cause
+    })
+  }
+}


### PR DESCRIPTION
Fix issue #101 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a small framework for consistent API responses and centralized error handling.
> 
> - Defines `ApiResponse<T>`, `ApiSuccessResponse`, `ApiErrorResponse` and builders `buildSuccessResponse`/`buildErrorResponse` in `types/server/api-response.ts`
> - Introduces `ApiError` base class with specific errors (`ValidationError`, `AuthenticationError`, `AuthorizationError`, `NotFoundError`, `InternalServerError`) in `types/server/errors.ts`
> - Adds error utilities in `types/server/error-handler.ts`: `toApiError`, `handleApiError` (returns `NextResponse.json` with status), and `withErrorHandling` HOF for wrapping route handlers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355cb90b7d2bb1acce0eebee0f58679afe9720be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->