### PR TITLE
ci: CI/CD pipeline setup (Epic #135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -51,10 +55,28 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:coverage
-      - name: Upload coverage
+      - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage/
           retention-days: 30
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+        env:
+          DATABASE_URL: 'postgresql://ci:ci@localhost:5432/ci'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,30 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Check for known vulnerabilities
+        run: pnpm audit --prod --audit-level=high

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An open-source platform for creating, managing, and serving Lightning Addresses 
 
 **Stack:** Next.js 16 + TypeScript + Prisma + PostgreSQL
 
+[![CI](https://github.com/lawalletio/lawallet-nwc/actions/workflows/ci.yml/badge.svg)](https://github.com/lawalletio/lawallet-nwc/actions/workflows/ci.yml)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flawalletio%2Flawallet-nwc&project-name=lawallet-nwc&repository-name=lawallet-nwc&demo-title=lawallet%20nwc&integration-ids=oac_3sK3gnG06emjIEVL09jjntDD)
 
 ---

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,21 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm prisma migrate deploy && next build"
+  "buildCommand": "pnpm prisma migrate deploy && next build",
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  },
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    }
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,14 +24,18 @@ export default defineConfig({
         'mocks',
         '**/*.d.ts',
         '**/*.config.*',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        '**/*.spec.ts',
+        '**/*.spec.tsx',
         '**/types/**',
         'prisma/**'
       ],
       thresholds: {
-        statements: 2,
-        branches: 25,
-        functions: 20,
-        lines: 2
+        statements: 60,
+        branches: 75,
+        functions: 70,
+        lines: 60
       }
     }
   },


### PR DESCRIPTION
## Summary

Completes Epic #135 — CI/CD Pipeline with all three sub-issues:

- **#119** — Configure coverage reporting: raised thresholds to 60/75/70/60%, fixed test file leaking into coverage metrics, added CI badge to README
- **#120** — Enhance GitHub Actions: added build verification job (gated on lint/typecheck/test), concurrency control for stale PR runs, new `security.yml` workflow for weekly dependency auditing
- **#121** — Configure Vercel CI/CD: added Next.js framework detection, git deployment config, security headers on API routes

## Test plan

- [x] `pnpm test:coverage` passes with new thresholds (71.75%/86.4%/83.33%/71.75%)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm typecheck` passes
- [x] CI workflow runs lint, typecheck, test, and build jobs on this PR
- [x] Security workflow runs dependency audit on this PR

Closes #119, closes #120, closes #121