### PR TITLE
docs: update auth docs for NIP-98 -> JWT session flow

### DIFF
--- a/docs/JWT_USAGE.md
+++ b/docs/JWT_USAGE.md
@@ -1,15 +1,39 @@
 # JWT Authentication System
 
-This document explains how to use the JWT authentication system in the Lawallet NWC application.
+This document explains the authentication system in the Lawallet NWC application, which combines NIP-98 (Nostr HTTP Auth) with JWT session tokens.
 
 ## Overview
 
-The JWT system provides secure authentication using JSON Web Tokens, similar to the NIP98 implementation. It includes:
+The authentication system uses a **NIP-98 Login -> JWT Session** approach:
 
-- **Server-side JWT library** (`lib/jwt.ts`) - Core JWT functions
-- **Authentication middleware** (`lib/jwt-auth.ts`) - Route protection utilities
-- **Client-side utilities** (`lib/jwt-client.ts`) - Token management on the frontend
-- **API endpoints** (`/api/jwt/*`) - Token creation and validation
+1. **Login**: The client signs a NIP-98 event (Nostr kind 27235) and sends it to `POST /api/jwt`
+2. **Session**: The server validates the Nostr signature, resolves the user's role, and returns a JWT with `pubkey`, `role`, and `permissions` baked in
+3. **Requests**: Subsequent API requests use the JWT via `Authorization: Bearer <token>`, avoiding repeated Nostr signatures
+4. **Dual Auth**: Routes accept both `Nostr` and `Bearer` authorization headers through a unified auth middleware
+
+### Architecture
+
+```
+Client                              Server
+  |                                   |
+  |-- NIP-98 signed event ----------->|  POST /api/jwt
+  |                                   |  validateNip98() -> resolveRole()
+  |<----------- JWT token ------------|  createJwtToken({ pubkey, role, permissions })
+  |                                   |
+  |-- Bearer <jwt> ------------------>|  GET /api/some-route
+  |                                   |  authenticate() -> reads role from JWT claims
+  |<----------- response -------------|
+```
+
+### Key Components
+
+- **Server-side JWT library** (`lib/jwt.ts`) - Core JWT functions (unchanged)
+- **Unified auth middleware** (`lib/auth/unified-auth.ts`) - Accepts both Nostr and Bearer auth
+- **Authentication middleware** (`lib/jwt-auth.ts`) - JWT-only route protection (for `/api/jwt/protected`)
+- **Client-side utilities** (`lib/jwt-client.ts`) - NIP-98 login flow + token management
+- **Role resolution** (`lib/auth/resolve-role.ts`) - DB lookup + root pubkey fallback
+- **Permissions** (`lib/auth/permissions.ts`) - RBAC model: USER < VIEWER < OPERATOR < ADMIN
+- **API endpoints** (`/api/jwt`, `/api/jwt/protected`) - Token creation and validation
 
 ## Setup
 
@@ -21,7 +45,7 @@ Add the following to your `.env.local` file:
 JWT_SECRET=your-super-secret-jwt-key-here
 ```
 
-**Important**: Use a strong, random secret key in production.
+**Important**: Use a strong, random secret key (at least 32 characters) in production.
 
 ### 2. Dependencies
 
@@ -29,143 +53,154 @@ The required packages are already installed:
 
 - `jsonwebtoken` - JWT creation and verification
 - `@types/jsonwebtoken` - TypeScript types
+- `@nostrify/nostrify` - Nostr signer interface for NIP-98
+
+## Authentication Flow
+
+### How It Works
+
+1. **Client** creates a NIP-98 event (kind 27235) signed with the user's Nostr key
+2. **Client** sends `Authorization: Nostr <base64-encoded-event>` to `POST /api/jwt`
+3. **Server** validates the NIP-98 event (signature, timestamp within 60s, URL/method binding)
+4. **Server** resolves the user's role from the database (or root pubkey from settings)
+5. **Server** creates a JWT with `pubkey`, `role`, and `permissions` in the claims
+6. **Client** stores the JWT and uses `Authorization: Bearer <jwt>` for subsequent requests
+7. **Server** routes use unified auth middleware that accepts either scheme
+
+### JWT Claims
+
+The JWT token contains:
+
+| Claim | Description | Example |
+|-------|-------------|---------|
+| `sub` / `userId` | User's Nostr pubkey (hex) | `"ab12...ef"` |
+| `pubkey` | Same as sub, explicit claim | `"ab12...ef"` |
+| `role` | User's RBAC role | `"ADMIN"` |
+| `permissions` | Role's permission set | `["manage_users", "manage_cards", ...]` |
+| `iss` | Token issuer | `"lawallet-nwc"` |
+| `aud` | Token audience | `"lawallet-users"` |
+| `exp` | Expiration timestamp | `1706832000` |
+| `iat` | Issued-at timestamp | `1706828400` |
 
 ## Server-Side Usage
 
-### Creating JWT Tokens
+### Unified Auth Middleware (Recommended)
+
+The unified auth middleware automatically detects the authorization scheme:
+
+```typescript
+import { authenticate, authenticateWithRole, authenticateWithPermission } from '@/lib/auth/unified-auth'
+import { Role } from '@/lib/auth/permissions'
+
+// Basic authentication (accepts Nostr or Bearer)
+export async function GET(request: Request) {
+  const { pubkey, role, method } = await authenticate(request)
+  // method is 'nip98' or 'jwt'
+  return NextResponse.json({ pubkey, role })
+}
+
+// Role-based authentication
+export async function POST(request: Request) {
+  const auth = await authenticateWithRole(request, Role.ADMIN)
+  // Throws AuthorizationError if user lacks the required role
+  return NextResponse.json({ admin: auth.pubkey })
+}
+
+// Permission-based authentication
+export async function DELETE(request: Request) {
+  const auth = await authenticateWithPermission(request, 'manage_cards')
+  return NextResponse.json({ ok: true })
+}
+```
+
+### Higher-Order Function (withAuth)
+
+```typescript
+import { withAuth } from '@/lib/auth/unified-auth'
+import { Role } from '@/lib/auth/permissions'
+import type { AuthResult } from '@/lib/auth/unified-auth'
+
+async function handler(request: Request, auth: AuthResult) {
+  return NextResponse.json({ pubkey: auth.pubkey, role: auth.role })
+}
+
+// Basic auth
+export const GET = withAuth(handler)
+
+// Require admin role
+export const POST = withAuth(handler, { requiredRole: Role.ADMIN })
+
+// Require specific permission
+export const DELETE = withAuth(handler, { requiredPermission: 'manage_cards' })
+
+// Force NIP-98 only (rejects Bearer tokens)
+export const PUT = withAuth(handler, { requireNip98: true })
+```
+
+### JWT-Only Routes
+
+For routes that only accept JWT (like the protected example endpoint):
+
+```typescript
+import { withJwtAuth, getUserIdFromRequest } from '@/lib/jwt-auth'
+import type { AuthenticatedRequest } from '@/lib/jwt-auth'
+
+async function protectedHandler(request: AuthenticatedRequest) {
+  const userId = getUserIdFromRequest(request)
+  return NextResponse.json({ message: `Hello ${userId}` })
+}
+
+export const GET = withJwtAuth(protectedHandler, {
+  requiredClaims: ['role', 'permissions']
+})
+```
+
+### Creating JWT Tokens (Server-Side)
 
 ```typescript
 import { createJwtToken } from '@/lib/jwt'
 
 const token = createJwtToken(
   {
-    userId: 'user123',
-    pubkey: 'pubkey123',
-    role: 'admin',
-    permissions: ['read', 'write']
+    userId: pubkey,
+    pubkey,
+    role: 'ADMIN',
+    permissions: ['manage_users', 'manage_cards']
   },
   process.env.JWT_SECRET!,
   {
-    expiresIn: '24h',
+    expiresIn: '1h',
     issuer: 'lawallet-nwc',
     audience: 'lawallet-users'
   }
 )
 ```
 
-### Verifying JWT Tokens
+### Resolving User Roles
 
 ```typescript
-import { verifyJwtToken } from '@/lib/jwt'
+import { resolveRole } from '@/lib/auth/resolve-role'
 
-try {
-  const result = verifyJwtToken(token, process.env.JWT_SECRET!)
-  console.log('User ID:', result.payload.sub)
-  console.log('Role:', result.payload.role)
-} catch (error) {
-  console.error('Token verification failed:', error.message)
-}
-```
-
-### Protecting API Routes
-
-#### Option 1: Using the middleware function
-
-```typescript
-import { authenticateJwt } from '@/lib/jwt-auth'
-import { NextRequest, NextResponse } from 'next/server'
-
-export async function GET(request: NextRequest) {
-  // Authenticate the request
-  const authResult = await authenticateJwt(request, {
-    requiredClaims: ['role']
-  })
-
-  if (authResult) {
-    return authResult // Returns error response if auth fails
-  }
-
-  // Request is authenticated, proceed with your logic
-  const userId = request.jwt?.payload.sub
-  return NextResponse.json({ message: `Hello user ${userId}` })
-}
-```
-
-#### Option 2: Using the higher-order function (Recommended)
-
-```typescript
-import { withJwtAuth, getUserIdFromRequest } from '@/lib/jwt-auth'
-import { NextResponse } from 'next/server'
-import type { AuthenticatedRequest } from '@/lib/jwt-auth'
-
-async function protectedHandler(request: AuthenticatedRequest) {
-  const userId = getUserIdFromRequest(request)
-
-  return NextResponse.json({
-    message: `Hello user ${userId}`,
-    timestamp: new Date().toISOString()
-  })
-}
-
-// Wrap with JWT authentication
-export const GET = withJwtAuth(protectedHandler, {
-  requiredClaims: ['role', 'permissions']
-})
-```
-
-### Working with Authenticated Requests
-
-```typescript
-import {
-  getUserIdFromRequest,
-  getClaimFromRequest,
-  hasClaim
-} from '@/lib/jwt-auth'
-
-async function handler(request: AuthenticatedRequest) {
-  // Get user ID
-  const userId = getUserIdFromRequest(request)
-
-  // Get specific claims
-  const role = getClaimFromRequest<string>(request, 'role')
-  const permissions = getClaimFromRequest<string[]>(request, 'permissions')
-
-  // Check claims
-  if (hasClaim(request, 'role', 'admin')) {
-    // Admin-only logic
-  }
-
-  if (hasClaim(request, 'permissions', 'write')) {
-    // Write permission logic
-  }
-}
+const role = await resolveRole(pubkey)
+// Returns: 'USER' | 'VIEWER' | 'OPERATOR' | 'ADMIN'
+// Checks: 1) User DB record, 2) Root pubkey from settings
 ```
 
 ## Client-Side Usage
 
-### Basic Token Management
+### Login with NIP-98
 
 ```typescript
 import { jwtClient } from '@/lib/jwt-client'
 
-// Request a new token
-const tokenData = await jwtClient.requestToken(
-  'user123',
-  { role: 'user', permissions: ['read'] },
-  '24h'
-)
+// 1. Set your Nostr signer (NIP-07 extension, NIP-46 bunker, etc.)
+jwtClient.setSigner(signer)
 
-// Check if token exists
-if (jwtClient.hasStoredToken()) {
-  console.log('User is authenticated')
-}
+// 2. Login - signs a NIP-98 event and exchanges it for a JWT
+const tokenData = await jwtClient.login('24h')
+// Returns: { token: "eyJ...", expiresIn: "24h", type: "Bearer" }
 
-// Get auth header for requests
-const authHeader = jwtClient.getAuthHeader()
-// Returns: "Bearer eyJhbGciOiJIUzI1NiIs..."
-
-// Logout
-jwtClient.logout()
+// Token is automatically stored in localStorage
 ```
 
 ### Making Authenticated Requests
@@ -173,50 +208,67 @@ jwtClient.logout()
 ```typescript
 import { jwtClient } from '@/lib/jwt-client'
 
-// Simple authenticated request
-const response = await jwtClient.authenticatedRequest('/api/protected-endpoint')
+// Authenticated request (auto-refreshes if token is near expiry)
+const response = await jwtClient.authenticatedRequest('/api/users/me')
 
 // With custom options
-const response = await jwtClient.authenticatedRequest('/api/users', {
+const response = await jwtClient.authenticatedRequest('/api/cards', {
   method: 'POST',
-  headers: {
-    'Content-Type': 'application/json'
-  },
-  body: JSON.stringify({ name: 'John Doe' })
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ designId: 'design_1' })
 })
 ```
 
-### Token Validation
+### Token Management
 
 ```typescript
 import { jwtClient } from '@/lib/jwt-client'
 
-// Validate stored token
+// Check if authenticated
+if (jwtClient.hasStoredToken()) {
+  console.log('User is authenticated')
+}
+
+// Get auth header for manual requests
+const authHeader = jwtClient.getAuthHeader()
+// Returns: "Bearer eyJhbGciOiJIUzI1NiIs..."
+
+// Validate token with server
 const isValid = await jwtClient.validateStoredToken()
 
-if (!isValid) {
-  // Token is invalid, redirect to login
-  jwtClient.logout()
-  // redirect to login page
-}
+// Refresh token (re-authenticates with NIP-98)
+const newToken = await jwtClient.refreshToken()
+
+// Logout (clears token and signer)
+jwtClient.logout()
 ```
+
+### Auto-Refresh Behavior
+
+When `autoRefresh` is enabled (default) and a signer is set:
+
+- `authenticatedRequest()` checks if the token is within `refreshThreshold` seconds of expiry (default: 300s / 5 minutes)
+- If near expiry, it automatically re-authenticates via NIP-98 and stores the new token
+- If no signer is set and the token expires, an error is thrown prompting the caller to login again
 
 ## API Endpoints
 
 ### POST /api/jwt
 
-Request a new JWT token.
+Authenticate with NIP-98 and receive a JWT session token.
 
-**Request Body:**
+**Headers:**
+
+```
+Authorization: Nostr <base64-encoded-kind-27235-event>
+Content-Type: application/json
+```
+
+**Request Body (optional):**
 
 ```json
 {
-  "userId": "user123",
-  "expiresIn": "24h",
-  "additionalClaims": {
-    "role": "admin",
-    "permissions": ["read", "write"]
-  }
+  "expiresIn": "24h"
 }
 ```
 
@@ -230,14 +282,19 @@ Request a new JWT token.
 }
 ```
 
+**Error Responses:**
+
+- `401` - Invalid or missing NIP-98 authentication
+- `500` - JWT_SECRET not configured
+
 ### GET /api/jwt
 
-Validate an existing JWT token.
+Validate an existing JWT token and return its claims.
 
 **Headers:**
 
 ```
-Authorization: Bearer <token>
+Authorization: Bearer <jwt-token>
 ```
 
 **Response:**
@@ -245,50 +302,109 @@ Authorization: Bearer <token>
 ```json
 {
   "valid": true,
-  "userId": "user123",
-  "issuedAt": "2024-01-01T00:00:00.000Z",
-  "expiresAt": "2024-01-02T00:00:00.000Z",
-  "additionalClaims": {
-    "role": "admin",
-    "permissions": ["read", "write"]
-  }
+  "pubkey": "ab12cd34ef56...",
+  "role": "ADMIN",
+  "permissions": ["manage_users", "manage_cards", "manage_settings"],
+  "issuedAt": "2026-02-14T00:00:00.000Z",
+  "expiresAt": "2026-02-14T01:00:00.000Z"
 }
 ```
 
+### Routes Using Unified Auth
+
+These routes accept both `Nostr` and `Bearer` authorization:
+
+| Route | Method | Auth Level |
+|-------|--------|------------|
+| `/api/users/me` | GET | Any authenticated user |
+| `/api/users/[id]/cards` | GET | Own user only |
+| `/api/users/[id]/nwc` | PUT | Own user only |
+| `/api/users/[id]/lightning-address` | PUT | Own user only |
+| `/api/cards/otc/[otc]/activate` | POST | Any authenticated user |
+| `/api/cards` | POST | ADMIN role required |
+
+### Routes Using NIP-98 Only (Admin)
+
+These routes require NIP-98 authentication directly (via `admin-auth.ts`):
+
+| Route | Method | Auth Level |
+|-------|--------|------------|
+| `/api/admin/root-assign` | POST | Root pubkey only |
+| `/api/users/[id]/role` | PUT | ADMIN role |
+| `/api/settings` | PUT | ADMIN role |
+| `/api/card-designs` | POST/PUT/DELETE | ADMIN role |
+| `/api/lightning-addresses` | POST/DELETE | ADMIN role |
+
+## RBAC Model
+
+### Role Hierarchy
+
+```
+USER < VIEWER < OPERATOR < ADMIN
+```
+
+Each role inherits all permissions from roles below it.
+
+### Permission Matrix
+
+| Permission | USER | VIEWER | OPERATOR | ADMIN |
+|------------|------|--------|----------|-------|
+| `view_own_data` | x | x | x | x |
+| `view_all_data` | | x | x | x |
+| `manage_cards` | | | x | x |
+| `manage_users` | | | | x |
+| `manage_settings` | | | | x |
+
+### Role Resolution
+
+1. Check `User` record in database for explicit role
+2. If pubkey matches the `root` setting, return `ADMIN`
+3. Default to `USER`
+
 ## Security Considerations
 
-1. **Secret Key**: Use a strong, random secret key and keep it secure
-2. **Token Expiration**: Set reasonable expiration times
-3. **HTTPS**: Always use HTTPS in production
-4. **Token Storage**: Store tokens securely (localStorage for client-side)
-5. **Claims**: Only include necessary claims in tokens
-6. **Validation**: Always validate tokens on the server side
+1. **JWT Secret**: Use a strong, random secret key (32+ characters) and keep it secure
+2. **Token Expiration**: Default is 1 hour; set reasonable expiration times for your use case
+3. **HTTPS**: Always use HTTPS in production (NIP-98 validates the full URL)
+4. **NIP-98 Window**: Events must be within 60 seconds of current time
+5. **Token Storage**: Client stores tokens in localStorage (sufficient for SPA use)
+6. **Role Baking**: JWT contains role at issuance time; role changes require new token
+7. **Step-Up Auth**: Sensitive admin operations (root assign, role changes) still require NIP-98 directly
 
 ## Error Handling
 
-The system provides detailed error messages for common issues:
+The system provides detailed error messages:
 
-- `Authorization header is required` - Missing auth header
-- `Authorization header must start with "Bearer "` - Invalid header format
-- `Token has expired` - Token is past expiration
-- `Invalid token` - Malformed or corrupted token
-- `Missing required claim: <claim>` - Required claim not present
+| Error | Status | Cause |
+|-------|--------|-------|
+| `Authorization header is required` | 401 | Missing auth header |
+| `Authorization header must use "Nostr" or "Bearer" scheme` | 401 | Unrecognized auth scheme |
+| `Invalid NIP-98 authentication` | 401 | Bad Nostr event signature, expired, etc. |
+| `Invalid or expired JWT` | 401 | Malformed or expired token |
+| `JWT authentication is not configured` | 401 | JWT_SECRET not set |
+| `Not authorized to access this resource` | 403 | Insufficient role |
+| `Not authorized to perform this action` | 403 | Missing permission |
 
 ## Examples
 
 See the following files for complete examples:
 
-- `app/api/jwt/protected/route.ts` - Protected endpoint example
-- `lib/jwt-auth.ts` - Authentication utilities
-- `lib/jwt-client.ts` - Client-side token management
+- `app/api/jwt/route.ts` - NIP-98 login endpoint
+- `app/api/jwt/protected/route.ts` - JWT-only protected endpoint
+- `lib/auth/unified-auth.ts` - Unified auth middleware
+- `lib/jwt-auth.ts` - JWT-specific authentication utilities
+- `lib/jwt-client.ts` - Client-side NIP-98 login + token management
+- `lib/auth/resolve-role.ts` - Role resolution logic
+- `lib/auth/permissions.ts` - RBAC permission definitions
 
-## Migration from NIP98
+## Migrating from Direct NIP-98
 
-If you're migrating from NIP98 to JWT:
+If your routes previously used `validateNip98` directly:
 
-1. Replace `createNip98Token` calls with `jwtClient.requestToken`
-2. Replace `validateNip98` calls with `withJwtAuth` wrapper
-3. Update client-side code to use `jwtClient.authenticatedRequest`
-4. Update environment variables (add `JWT_SECRET`)
+1. Replace `import { validateNip98 } from '@/lib/nip98'` with `import { authenticate } from '@/lib/auth/unified-auth'`
+2. Replace `const { pubkey } = await validateNip98(request)` with `const { pubkey } = await authenticate(request)`
+3. For admin routes, use `authenticateWithRole(request, Role.ADMIN)` instead of `validateAdminAuth(request)`
+4. Client-side: replace manual NIP-98 header creation with `jwtClient.setSigner(signer)` + `jwtClient.login()`
+5. Client-side: replace manual `Authorization: Nostr` headers with `jwtClient.authenticatedRequest(url)`
 
-The JWT system provides similar functionality with better performance and broader compatibility.
+Routes updated to unified auth automatically accept both NIP-98 and JWT authentication, providing backward compatibility.

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -22,7 +22,7 @@ Two packages provide typed access to the LaWallet NWC backend:
 - **Lightning Address**: create, lookup, update, delete
 - **Alias/Redirect**: set target, remove, get status
 - **NWC Connection**: connect, disconnect, status
-- **Authentication**: JWT login, Nostr login, refresh, revoke
+- **Authentication**: NIP-98 login → JWT session, token refresh, logout
 - **Webhooks**: subscribe, unsubscribe, list
 - **Wallet**: balance, send, receive
 
@@ -53,7 +53,7 @@ Two packages provide typed access to the LaWallet NWC backend:
 | `useAddresses` | List/search/filter with pagination | 2 |
 | `useNWCConnection` | Connect, disconnect, status polling | 2 |
 | `usePayments` | Payment history, real-time updates | 2 |
-| `useAuth` | JWT + Nostr login, session state, logout | 2 |
+| `useAuth` | NIP-98 login → JWT session, session state, logout | 2 |
 | `useWebhooks` | Subscribe, unsubscribe, list active hooks | 2 |
 | `useWallet` | Balance, send, receive, NWC status | 2 |
 | `useCourtesyNWC` | Provision/revoke courtesy NWC from proxy | 3 |

--- a/docs/roadmap/MONTH-2.md
+++ b/docs/roadmap/MONTH-2.md
@@ -46,7 +46,7 @@ With backend infrastructure, logging, auth, and testing delivered ahead of sched
 - Lightning address operations: create, lookup, delete
 - Card management: CRUD, scan, write, OTC activation
 - User management: profile, role, NWC URI
-- Authentication helpers: JWT creation, NIP-98 signing
+- Authentication helpers: NIP-98 login → JWT session, unified auth (Nostr + Bearer)
 - Admin operations: settings, assign roles
 
 ### Technical
@@ -68,7 +68,7 @@ With backend infrastructure, logging, auth, and testing delivered ahead of sched
 | `useAddresses` | List/search addresses | Pagination, filtering, search |
 | `useNWCConnection` | NWC wallet management | Connect, disconnect, status polling |
 | `usePayments` | Payment history | Real-time updates, filtering |
-| `useAuth` | Authentication | JWT + Nostr login, session state, logout |
+| `useAuth` | Authentication | NIP-98 login → JWT session, session state, logout |
 | `useWebhooks` | Webhook management | Subscribe, unsubscribe, list active |
 | `useWallet` | Wallet operations | Balance, send, receive, NWC status |
 

--- a/docs/roadmap/MONTH-3.md
+++ b/docs/roadmap/MONTH-3.md
@@ -65,7 +65,7 @@ The admin dashboard already has a functional base (cards, designs, addresses, se
 
 - Detect Nostr extensions (Alby, nos2x, etc.)
 - Sign NIP-98 auth events via `window.nostr.signEvent()`
-- Login flow: detect extension → request pubkey → sign auth event → create session
+- Login flow: detect extension → request pubkey → `jwtClient.setSigner(signer)` → `jwtClient.login()`
 
 ### NIP-46: Remote Signing (Bunker Protocol)
 
@@ -73,10 +73,12 @@ The admin dashboard already has a functional base (cards, designs, addresses, se
 - Remote signing for users without browser extensions
 - Fallback for mobile and extension-less browsers
 
-### Session Management
+### Session Management (Backend Implemented)
 
-- JWT session tokens (backend already supports this)
-- Automatic token refresh
+- NIP-98 login → JWT session flow (`POST /api/jwt` with Nostr auth)
+- JWT tokens contain `pubkey`, `role`, `permissions` claims
+- Automatic token refresh via NIP-98 re-authentication (`jwtClient.refreshToken()`)
+- Unified auth middleware accepts both `Nostr` and `Bearer` authorization headers
 - Unified login modal with method selection
 
 ---

--- a/docs/roadmap/MONTH-6.md
+++ b/docs/roadmap/MONTH-6.md
@@ -23,7 +23,7 @@ Finalize all documentation, configure deployment targets, and prepare the codeba
 
 - OpenAPI/Swagger specification for all 30 API routes
 - Request/response schemas derived from existing Zod validation schemas
-- Authentication requirements per endpoint (NIP-98, JWT, public)
+- Authentication requirements per endpoint (NIP-98 only, unified auth (Nostr + Bearer), JWT only, public)
 - Example payloads for every endpoint
 - Deploy interactive documentation at `/docs/api` (Swagger UI or Redoc)
 
@@ -37,7 +37,7 @@ Finalize all documentation, configure deployment targets, and prepare the codeba
 - Data flow for payments (NWC and alias/redirect)
 - Address resolution priority logic
 - Service communication patterns
-- Auth chain documentation (NIP-98 → admin-auth → permissions)
+- Auth chain documentation (NIP-98 login → JWT session → unified-auth → RBAC permissions)
 
 ### CONTRIBUTING.md
 

--- a/docs/services/LAWALLET-WEB.md
+++ b/docs/services/LAWALLET-WEB.md
@@ -65,9 +65,9 @@ The main application serving the frontend, REST API, admin dashboard, user dashb
 
 ### API
 
-- `POST /api/auth/login` — JWT login
-- `POST /api/auth/refresh` — Refresh token
-- `POST /api/auth/nostr` — Nostr login (NIP-07/NIP-46)
+- `POST /api/jwt` — NIP-98 login (exchange Nostr auth event for JWT session token)
+- `GET /api/jwt` — Validate JWT and return claims (pubkey, role, permissions)
+- `GET /api/jwt/protected` — Example JWT-protected endpoint
 - `GET /api/addresses` — List addresses
 - `POST /api/addresses` — Create address
 - `GET /api/addresses/:id` — Get address details


### PR DESCRIPTION
## Summary
- **Rewrite `JWT_USAGE.md`**: Comprehensive update documenting the new NIP-98 login → JWT session architecture, unified auth middleware, RBAC claims, client login flow, route auth matrix, and migration guide
- **Update roadmap and service docs**: Reflect the implemented auth approach across MONTH-2, MONTH-3, MONTH-6, SDK.md, and LAWALLET-WEB.md

## Context
This is a follow-up to PR #184 which implemented the NIP-98 → JWT session auth system. These doc changes were not included in that PR's merge.

## Files Changed
| File | Change |
|------|--------|
| `docs/JWT_USAGE.md` | Full rewrite — architecture diagram, unified auth API, client login flow, route matrix, RBAC model, migration guide |
| `docs/SDK.md` | Updated auth method descriptions |
| `docs/services/LAWALLET-WEB.md` | Fixed auth endpoint URLs to match actual routes |
| `docs/roadmap/MONTH-2.md` | Updated auth helpers and `useAuth` hook descriptions |
| `docs/roadmap/MONTH-3.md` | Updated Nostr login section with implemented backend flow |
| `docs/roadmap/MONTH-6.md` | Updated auth chain documentation references |

## Test plan
- [x] Documentation only — no code changes, no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime behavior or security logic is modified, but inaccurate docs could mislead integrators if not reviewed for correctness.
> 
> **Overview**
> Updates docs to reflect the implemented **NIP-98 login → JWT session** flow, where clients exchange a signed NIP-98 event for a JWT containing `pubkey`, `role`, and `permissions`, and then use `Authorization: Bearer` for subsequent requests.
> 
> Rewrites `docs/JWT_USAGE.md` with unified auth middleware usage (`authenticate`/`withAuth`), RBAC/permissions and role-resolution details, client login + auto-refresh behavior, updated `/api/jwt` request/response examples, route auth matrices (unified vs NIP-98-only admin), and a migration guide from direct `validateNip98` usage.
> 
> Aligns other documentation (`docs/SDK.md`, roadmap months, and `docs/services/LAWALLET-WEB.md`) to consistently describe the same auth approach and correct endpoint references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc1ca6554ca0566feba107903c46113cd26321bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->