### PR TITLE
docs(lib): JSDoc on public lib/ surface for IDE tooltips

### DIFF
--- a/apps/web/lib/activity-log.ts
+++ b/apps/web/lib/activity-log.ts
@@ -5,6 +5,12 @@ import { eventBus } from '@/lib/events/event-bus'
 
 export type { ActivityCategory, ActivityLevel, ActivityLog }
 
+/**
+ * Stable string codes for every event the app records. Stored verbatim in
+ * `ActivityLog.event` and used as filter keys in the admin UI — renaming a
+ * value silently breaks historical queries, so prefer adding new codes over
+ * renaming existing ones.
+ */
 export const ActivityEvent = {
   // USER
   USER_JWT_ISSUED: 'user.jwt_issued',
@@ -93,6 +99,7 @@ function toIso(value: Date | string | null | undefined): string | null {
   return String(value)
 }
 
+/** Input shape for {@link logActivity} — `level` defaults to `'INFO'`. */
 export interface LogActivityInput {
   category: ActivityCategory
   event: ActivityEventCode | string
@@ -155,13 +162,19 @@ async function logActivityImpl(input: LogActivityInput): Promise<ActivityLog> {
   return row
 }
 
+/**
+ * Persists an `ActivityLog` row, mirrors the line into Pino, and broadcasts an
+ * `activity:new` SSE event. Awaitable when the caller needs the row id.
+ */
 export async function logActivity(input: LogActivityInput): Promise<ActivityLog> {
   return logActivityImpl(input)
 }
 
-// Fire-and-forget variant. Callers use this from hot paths where logging must
-// never throw or await — e.g. route handlers where a broken DB connection for
-// the ActivityLog table should not kill the user-facing request.
+/**
+ * Fire-and-forget variant. Use from hot paths where logging must never throw
+ * or block — a broken DB connection for the `ActivityLog` table should not
+ * kill the user-facing request. Errors are caught and logged via Pino.
+ */
 logActivity.fireAndForget = (input: LogActivityInput): void => {
   logActivityImpl(input).catch(err => {
     logger.error({ err, activity_input: input }, 'activity_log.write_failed')

--- a/apps/web/lib/albyhub.ts
+++ b/apps/web/lib/albyhub.ts
@@ -1,25 +1,46 @@
+/** Shape returned by `POST /apps` on Alby Hub for a new isolated sub-account. */
 export interface AlbyCreateSubAccountResponse {
+  /** NWC pairing URI to hand to the new user's wallet. */
   pairingUri: string
   pairingSecretKey: string
   pairingPublicKey: string
   relayUrl: string
   walletPubkey: string
+  /** Lightning address minted by Alby for the sub-account. */
   lud16: string
+  /** Alby-side numeric app id — keep this to wire follow-up calls. */
   id: number
   name: string
   returnTo: string
 }
 
+/**
+ * Thin client for the self-hosted Alby Hub HTTP API. Used by the signup flow
+ * to provision a per-user wallet and lightning address when the operator has
+ * enabled the integration.
+ */
 export class AlbyHub {
   private readonly url: string
   private readonly bearerToken: string
 
+  /**
+   * @param url - Alby Hub base URL (e.g. `https://hub.example.com`).
+   * @param bearerToken - Hub API token with permission to mint sub-accounts.
+   */
   constructor(url: string, bearerToken: string) {
     console.info('Initializing AlbyHub with URL:', url)
     this.url = url
     this.bearerToken = bearerToken
   }
 
+  /**
+   * Creates an isolated sub-account on the hub with the standard NWC scopes.
+   *
+   * @param name - Display name for the sub-account (typically `LaWallet-<userId>`).
+   * @param subAccount - When `true` (default), tags the app with the
+   *   `uncle-jim` metadata so it shows in Alby Hub's "Friends and Family" UI.
+   * @throws {Error} `'Failed to create sub account'` on a non-2xx response.
+   */
   async createSubAccount(name: string, subAccount: boolean = true) {
     console.info('Creating sub account with name:', name)
     console.info('Sub account flag:', subAccount)
@@ -68,6 +89,11 @@ export class AlbyHub {
     return data
   }
 
+  /**
+   * Mints a Lightning Address on the hub bound to an existing app.
+   *
+   * @throws {Error} `'Failed to create a lightning address'` on a non-2xx response.
+   */
   async createLightningAddress(username: string, appId: string) {
     console.info('Creating lightning address:', username)
     console.info('For app ID:', appId)

--- a/apps/web/lib/auth/permissions.ts
+++ b/apps/web/lib/auth/permissions.ts
@@ -1,3 +1,7 @@
+/**
+ * Authentication roles in ascending privilege.
+ * USER < VIEWER < OPERATOR < ADMIN.
+ */
 export enum Role {
   ADMIN = 'ADMIN',
   OPERATOR = 'OPERATOR',
@@ -7,6 +11,10 @@ export enum Role {
 
 const ROLE_HIERARCHY: Role[] = [Role.USER, Role.VIEWER, Role.OPERATOR, Role.ADMIN]
 
+/**
+ * Granular permissions checked by RBAC guards. Each role maps to a fixed
+ * subset via `ROLE_PERMISSIONS`; ADMIN gets every permission by definition.
+ */
 export enum Permission {
   SETTINGS_READ = 'settings:read',
   SETTINGS_WRITE = 'settings:write',
@@ -50,18 +58,32 @@ const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
   [Role.USER]: [],
 }
 
+/**
+ * @returns `true` if `role` is granted `permission` via the static role→permission map.
+ */
 export function hasPermission(role: Role, permission: Permission): boolean {
   return ROLE_PERMISSIONS[role].includes(permission)
 }
 
+/**
+ * Hierarchy check — `true` when `role` is at least as privileged as `requiredRole`.
+ * @param role - The actor's resolved role.
+ * @param requiredRole - The minimum role demanded by the caller.
+ */
 export function hasRole(role: Role, requiredRole: Role): boolean {
   return ROLE_HIERARCHY.indexOf(role) >= ROLE_HIERARCHY.indexOf(requiredRole)
 }
 
+/**
+ * @returns A defensive copy of the permissions assigned to `role`.
+ */
 export function getRolePermissions(role: Role): Permission[] {
   return [...ROLE_PERMISSIONS[role]]
 }
 
+/**
+ * Type guard narrowing an arbitrary string to a known {@link Role}.
+ */
 export function isValidRole(value: string): value is Role {
   return Object.values(Role).includes(value as Role)
 }

--- a/apps/web/lib/auth/resolve-role.ts
+++ b/apps/web/lib/auth/resolve-role.ts
@@ -4,7 +4,12 @@ import { Role } from './permissions'
 
 /**
  * Resolves the role for an authenticated pubkey.
- * Checks the User record first, falls back to Settings root check for backwards compatibility.
+ * Checks the User record first; falls back to the legacy Settings `root`
+ * value so a freshly-bootstrapped instance still recognises its admin
+ * before any User row exists.
+ *
+ * @param pubkey - Hex-encoded Nostr pubkey of the authenticated actor.
+ * @returns The resolved role, defaulting to {@link Role.USER} when nothing matches.
  */
 export async function resolveRole(pubkey: string): Promise<Role> {
   const user = await prisma.user.findUnique({

--- a/apps/web/lib/auth/unified-auth.ts
+++ b/apps/web/lib/auth/unified-auth.ts
@@ -6,11 +6,16 @@ import { AuthenticationError, AuthorizationError } from '@/types/server/errors'
 import { Role, Permission, hasRole, hasPermission, isValidRole } from '@/lib/auth/permissions'
 import { resolveRole } from '@/lib/auth/resolve-role'
 
+/** Authentication scheme used to identify the caller. */
 export type AuthMethod = 'nip98' | 'jwt'
 
+/** Resolved identity returned by the auth helpers. */
 export interface AuthResult {
+  /** Hex-encoded Nostr pubkey of the authenticated actor. */
   pubkey: string
+  /** Role resolved for the actor (USER when nothing matched). */
   role: Role
+  /** Scheme used for the request — useful for audit logging. */
   method: AuthMethod
 }
 
@@ -85,7 +90,10 @@ async function authenticateJwt(request: Request): Promise<AuthResult> {
 }
 
 /**
- * Authenticates and checks that the user has at least the required role.
+ * Authenticates and verifies the actor satisfies the role hierarchy.
+ *
+ * @throws {AuthenticationError} When the request lacks valid credentials.
+ * @throws {AuthorizationError} When the resolved role is below `requiredRole`.
  */
 export async function authenticateWithRole(
   request: Request,
@@ -101,7 +109,10 @@ export async function authenticateWithRole(
 }
 
 /**
- * Authenticates and checks that the user has a specific permission.
+ * Authenticates and verifies the actor holds the given permission.
+ *
+ * @throws {AuthenticationError} When the request lacks valid credentials.
+ * @throws {AuthorizationError} When the resolved role does not grant `permission`.
  */
 export async function authenticateWithPermission(
   request: Request,
@@ -117,7 +128,13 @@ export async function authenticateWithPermission(
 }
 
 /**
- * HOF: wraps a route handler with unified auth (Nostr or JWT).
+ * Wraps a route handler with unified auth (Nostr or JWT) and forwards the
+ * resolved {@link AuthResult} as the second argument.
+ *
+ * @param handler - The handler to invoke after a successful auth.
+ * @param options - Optional gate. `requireNip98` forces Nostr-only auth (used
+ *   by endpoints that mint JWTs); otherwise checks `requiredPermission` first,
+ *   then `requiredRole`, then plain authentication.
  */
 export function withAuth<T extends any[]>(
   handler: (request: Request, auth: AuthResult, ...args: T) => Promise<NextResponse>,

--- a/apps/web/lib/client/contacts-store.ts
+++ b/apps/web/lib/client/contacts-store.ts
@@ -4,12 +4,14 @@ import { useSyncExternalStore } from 'react'
 
 const STORAGE_KEY = 'lawallet-contacts'
 
+/** Saved-recipient entry persisted in localStorage by the wallet send flow. */
 export interface Contact {
   id: string
   name: string
   lightningAddress: string
   npub?: string | null
   avatarUrl?: string | null
+  /** Epoch ms; used purely for ordering in the UI. */
   createdAt: number
 }
 
@@ -67,6 +69,10 @@ function genId() {
   return rand
 }
 
+/**
+ * Subscribes to the contacts list. Returns the most-recently-added entries
+ * first. Empty during SSR — the data is localStorage-only on purpose.
+ */
 export function useContacts(): Contact[] {
   return useSyncExternalStore(
     subscribe,
@@ -75,6 +81,7 @@ export function useContacts(): Contact[] {
   )
 }
 
+/** Mutation surface for the contacts store — all writes notify subscribers. */
 export const contactsActions = {
   add(input: Omit<Contact, 'id' | 'createdAt'>): Contact {
     const contact: Contact = {

--- a/apps/web/lib/client/currencies-store.ts
+++ b/apps/web/lib/client/currencies-store.ts
@@ -127,6 +127,11 @@ export function useActiveCurrencies(): Currency[] {
   return out
 }
 
+/**
+ * Mutation surface for the currencies store. All writes go through these to
+ * keep the locked-codes invariant ({@link CURRENCY_CATALOG} entries with
+ * `locked: true` always remain at the front of the list).
+ */
 export const currenciesActions = {
   add(code: string) {
     if (!CURRENCY_CATALOG.some(c => c.code === code)) return

--- a/apps/web/lib/client/hooks/use-activity.ts
+++ b/apps/web/lib/client/hooks/use-activity.ts
@@ -61,6 +61,12 @@ function toView(log: ActivityLog): ActivityLogView {
 
 const PAGE_SIZE = 20
 
+/**
+ * Cursor-paginated activity feed for the admin dashboard. The first page
+ * loads on mount (and refetches when filters change) and `loadMore` appends
+ * the next cursor. Subscribes to the `activity:new` SSE event and refetches
+ * the first page when one arrives so the table picks up new rows live.
+ */
 export function useActivity(filters: ActivityFilters = {}): UseActivityResult {
   const { apiClient, status } = useAuth()
   const [data, setData] = useState<ActivityLogView[]>([])

--- a/apps/web/lib/client/nfc-card-id.ts
+++ b/apps/web/lib/client/nfc-card-id.ts
@@ -16,6 +16,7 @@ export function stripCardId(input: string): string {
   return input.replace(/[\s:]+/g, '').toUpperCase()
 }
 
+/** True when `input` decodes to a 4- or 7-byte NFC UID (any casing/colon style). */
 export function isValidCardId(input: string): boolean {
   const hex = stripCardId(input)
   if (!/^[0-9A-F]+$/.test(hex)) return false

--- a/apps/web/lib/events/event-bus.ts
+++ b/apps/web/lib/events/event-bus.ts
@@ -4,6 +4,7 @@ import type { SSEEvent, SSEEventType } from '@/lib/events/event-types'
 // Re-export shared types so existing imports continue to work
 export type { SSEEvent, SSEEventType }
 
+/** A connected SSE subscriber. The bus filters events by `permissions`. */
 export interface SSEClient {
   id: string
   controller: ReadableStreamDefaultController
@@ -25,21 +26,34 @@ const EVENT_PERMISSION_MAP: Record<SSEEventType, Permission | null> = {
 
 // ─── Event Bus ────────────────────────────────────────────────────────────
 
+/**
+ * In-process pub/sub for the SSE endpoint. Singleton — see `eventBus` below.
+ * Permission-aware: events only reach clients whose permissions include the
+ * required scope from `EVENT_PERMISSION_MAP`.
+ */
 class EventBus {
   private clients: Map<string, SSEClient> = new Map()
 
+  /** Registers a new SSE subscriber. Idempotent on `client.id`. */
   addClient(client: SSEClient): void {
     this.clients.set(client.id, client)
   }
 
+  /** Drops a subscriber. Safe to call on an unknown id. */
   removeClient(id: string): void {
     this.clients.delete(id)
   }
 
+  /** Number of connected subscribers — used by the diagnostics endpoint. */
   getClientCount(): number {
     return this.clients.size
   }
 
+  /**
+   * Broadcasts an event to every subscriber whose permissions allow it.
+   * Subscribers that throw on `enqueue` (typically because they disconnected)
+   * are silently removed.
+   */
   emit(event: SSEEvent): void {
     const requiredPermission = EVENT_PERMISSION_MAP[event.type]
     const sseData = `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`
@@ -74,6 +88,7 @@ const globalForEventBus = globalThis as unknown as {
   eventBus: EventBus | undefined
 }
 
+/** Process-wide SSE broadcast bus. Survives Next.js HMR via `globalThis`. */
 export const eventBus = globalForEventBus.eventBus ?? new EventBus()
 
 if (process.env.NODE_ENV !== 'production') {

--- a/apps/web/lib/jwt.ts
+++ b/apps/web/lib/jwt.ts
@@ -1,24 +1,31 @@
 import jwt from 'jsonwebtoken'
 
+/** Decoded JWT payload used by this app. Open via index signature for custom claims. */
 export interface JwtPayload {
-  userId: string // subject (user ID)
-  pubkey: string // public key
-  iat: number // issued at
-  exp: number // expiration time
-  [key: string]: any // allow additional claims
+  /** Subject — typically the user's DB id. */
+  userId: string
+  /** Hex-encoded Nostr pubkey of the actor. */
+  pubkey: string
+  /** Issued-at, epoch seconds. */
+  iat: number
+  /** Expiration, epoch seconds. */
+  exp: number
+  /** Additional claims (role, etc.). */
+  [key: string]: any
 }
 
+/** Result returned by the verify/decode helpers — payload plus the JOSE header. */
 export interface JwtValidationResult {
   payload: JwtPayload
   header: any
 }
 
 /**
- * Creates a JWT token with the given payload
- * @param payload - The payload to encode in the JWT
- * @param secret - The secret key to sign the JWT
- * @param options - Additional JWT options
- * @returns string - The encoded JWT token
+ * Signs a JWT. `iat`, `exp`, and `pubkey` are intentionally excluded from
+ * `payload` — `iat`/`exp` come from `expiresIn`, and `pubkey` is added by the
+ * caller as part of the broader claims it spreads in.
+ *
+ * @returns The encoded JWT (`xxx.yyy.zzz`).
  */
 export function createJwtToken(
   payload: Omit<JwtPayload, 'iat' | 'exp' | 'pubkey'>,
@@ -44,11 +51,14 @@ export function createJwtToken(
 }
 
 /**
- * Verifies and decodes a JWT token
+ * Verifies and decodes a JWT token.
+ *
  * @param token - The JWT token to verify
  * @param secret - The secret key to verify the JWT
  * @param options - Additional verification options
- * @returns JwtValidationResult - The decoded payload and header
+ * @returns The decoded payload and header
+ * @throws {Error} `'Token has expired'`, `'Invalid token'`, `'Token not active yet'`,
+ *   or a wrapped verification error.
  */
 export function verifyJwtToken(
   token: string,
@@ -99,9 +109,11 @@ export function verifyJwtToken(
 }
 
 /**
- * Decodes a JWT token without verification (use with caution)
- * @param token - The JWT token to decode
- * @returns JwtValidationResult - The decoded payload and header
+ * Decodes a JWT *without* verifying its signature — only safe for inspecting
+ * a token (e.g. reading `exp` to schedule a refresh) when you don't yet trust it.
+ * Never use the returned claims for authorization.
+ *
+ * @throws {Error} `'Invalid token format'` or a wrapped decoding error.
  */
 export function decodeJwtToken(token: string): JwtValidationResult {
   try {
@@ -123,9 +135,9 @@ export function decodeJwtToken(token: string): JwtValidationResult {
 }
 
 /**
- * Extracts JWT token from Authorization header
- * @param authHeader - The Authorization header value
- * @returns string - The extracted JWT token
+ * Extracts the bearer token from an `Authorization: Bearer <token>` header.
+ *
+ * @throws {Error} When the header is missing, lacks the `Bearer ` prefix, or is empty.
  */
 export function extractJwtFromHeader(authHeader: string | null): string {
   if (!authHeader) {
@@ -146,11 +158,9 @@ export function extractJwtFromHeader(authHeader: string | null): string {
 }
 
 /**
- * Validates a JWT token from a Request object
- * @param request - The Request object containing the authorization header
- * @param secret - The secret key to verify the JWT
- * @param options - Additional verification options
- * @returns Promise<JwtValidationResult> - The validated JWT data
+ * Convenience wrapper: pulls the bearer token from a `Request` and verifies it.
+ *
+ * @throws {Error} See {@link extractJwtFromHeader} and {@link verifyJwtToken}.
  */
 export async function validateJwtFromRequest(
   request: Request,
@@ -169,10 +179,9 @@ export async function validateJwtFromRequest(
 }
 
 /**
- * Checks if a JWT token is expired
- * @param payload - The JWT payload
- * @param clockTolerance - Clock tolerance in seconds (default: 0)
- * @returns boolean - True if token is expired
+ * Checks whether a decoded payload is past its `exp`.
+ *
+ * @param clockTolerance - Optional skew, in seconds, applied in the caller's favour.
  */
 export function isTokenExpired(
   payload: JwtPayload,
@@ -183,9 +192,7 @@ export function isTokenExpired(
 }
 
 /**
- * Gets the time until a JWT token expires
- * @param payload - The JWT payload
- * @returns number - Seconds until expiration (negative if expired)
+ * @returns Seconds until the payload's `exp` (negative when already expired).
  */
 export function getTimeUntilExpiration(payload: JwtPayload): number {
   const now = Math.floor(Date.now() / 1000)

--- a/apps/web/lib/logger.ts
+++ b/apps/web/lib/logger.ts
@@ -48,6 +48,10 @@ function getReqIdFromContext(): string | undefined {
   return requestContext.getStore()?.reqId
 }
 
+/**
+ * Returns the request id active for the current AsyncLocalStorage frame, or
+ * `undefined` outside a {@link withRequestLogging}-wrapped handler.
+ */
 export function getCurrentReqId(): string | undefined {
   return getReqIdFromContext()
 }
@@ -96,6 +100,11 @@ function trySetResponseHeader(res: unknown, name: string, value: string) {
   }
 }
 
+/**
+ * Returns the first acceptable request-id from common upstream headers
+ * (`x-request-id`, `x-correlation-id`, `x-amzn-trace-id`), bounded to 200
+ * chars to keep log lines tidy. Generates a fresh UUID when none qualify.
+ */
 export function getOrCreateRequestId(headers?: Headers): string {
   const fromHeader =
     headers?.get('x-request-id')?.trim() ||
@@ -106,6 +115,10 @@ export function getOrCreateRequestId(headers?: Headers): string {
   return randomUUID()
 }
 
+/**
+ * Runs `fn` inside an AsyncLocalStorage frame so any `logger` call within
+ * (or any awaited descendant) automatically tags log lines with `ctx.reqId`.
+ */
 export function runWithRequestContext<T>(ctx: RequestContext, fn: () => T): T {
   return requestContext.run(ctx, fn)
 }
@@ -136,10 +149,18 @@ export const logger: Logger = pino({
     : undefined
 })
 
+/**
+ * Returns a child logger pre-tagged with `context` (e.g. `{ module: 'jwt' }`).
+ * Without `context`, returns the root `logger` unchanged.
+ */
 export function createLogger(context?: Record<string, unknown>) {
   return context ? logger.child(context) : logger
 }
 
+/**
+ * Convenience for logging an error with optional structured context. Uses Pino's
+ * standard `err` serializer so stack traces render cleanly in JSON output.
+ */
 export function logError(err: unknown, context?: Record<string, unknown>) {
   logger.error({ err, ...context }, 'error')
 }

--- a/apps/web/lib/middleware/rate-limit.ts
+++ b/apps/web/lib/middleware/rate-limit.ts
@@ -57,8 +57,10 @@ if (typeof setInterval !== 'undefined') {
 }
 
 /**
- * Extract client IP from request
- * Handles common proxy headers
+ * Extracts the client IP from common proxy headers.
+ * Checks `x-forwarded-for` (first hop), then `x-real-ip`, then `cf-connecting-ip`.
+ *
+ * @returns The resolved IP, or `'unknown'` when no proxy header is present.
  */
 export function getClientIp(request: Request): string {
   // Check common proxy headers
@@ -176,8 +178,11 @@ export function applyRateLimitHeaders(
 }
 
 /**
- * Rate limiting middleware for API routes
- * Throws TooManyRequestsError if limit exceeded
+ * Rate-limiting middleware for API routes. Logs at `warn` and throws when the
+ * caller exceeds their bucket; otherwise returns the bucket metadata so the
+ * handler can attach `X-RateLimit-*` headers via {@link applyRateLimitHeaders}.
+ *
+ * @throws {TooManyRequestsError} When the bucket for this identifier is exhausted.
  *
  * @example
  * ```ts

--- a/apps/web/lib/nip98.ts
+++ b/apps/web/lib/nip98.ts
@@ -2,6 +2,7 @@ import { NostrSigner } from '@nostrify/nostrify'
 import { nip98, NostrEvent } from 'nostr-tools'
 import { getToken } from 'nostr-tools/nip98'
 
+/** Outcome of validating a NIP-98 token — the verified pubkey and the raw event. */
 export interface Nip98ValidationResult {
   pubkey: string
   event: NostrEvent
@@ -46,6 +47,12 @@ export function generateAbsoluteUrl(url: string, baseUrl?: string): string {
   return base + url
 }
 
+/**
+ * Normalises a `RequestInit.body` into the plain object that NIP-98 hashes.
+ * Non-JSON strings are wrapped as `{ body: '<string>' }` so the hash is stable.
+ *
+ * @returns The payload to feed to `getToken`, or `undefined` for empty bodies.
+ */
 export function bodyToPayload(body: any): Record<string, any> | undefined {
   let payload: Record<string, any> | undefined
   if (body) {
@@ -111,10 +118,18 @@ export async function createNip98Token(
 }
 
 /**
- * Validates a NIP-98 authentication token
- * @param request - The Request object containing the authorization header
- * @param timeDelta - The time difference in seconds for event timestamp validation
- * @returns Promise<Nip98ValidationResult> - The validated event data
+ * Validates a NIP-98 authentication token from a `Request`.
+ *
+ * The signed event commits to the *public* URL the client typed, not the
+ * internal one Next.js sees behind a proxy/tunnel. We reconstruct that URL
+ * from `x-forwarded-host` / `x-forwarded-proto` (falling back to `host` and
+ * the request scheme) so signatures verify in development tunnels and
+ * production proxies alike.
+ *
+ * @param request - The incoming HTTP request
+ * @param timeDelta - Allowed clock skew in seconds for the event's `created_at`
+ * @returns The verified pubkey and full event
+ * @throws {Error} On missing/malformed header, signature mismatch, or stale timestamp.
  */
 export async function validateNip98(
   request: Request,

--- a/apps/web/lib/nostr.ts
+++ b/apps/web/lib/nostr.ts
@@ -2,21 +2,35 @@ import { generateSecretKey, getPublicKey } from 'nostr-tools/pure'
 import { nip19 } from 'nostr-tools'
 import { bytesToHex, hexToBytes } from 'nostr-tools/utils'
 
+/**
+ * @returns A freshly-generated 32-byte Nostr secret key as lowercase hex.
+ */
 export function generatePrivateKey(): string {
   const secretKey = generateSecretKey()
   return bytesToHex(secretKey)
 }
 
+/**
+ * Derives the secp256k1 x-only public key for a hex secret key.
+ */
 export function getPublicKeyFromPrivate(privateKeyHex: string): string {
   const privateKeyBytes = hexToBytes(privateKeyHex)
   return getPublicKey(privateKeyBytes)
 }
 
+/**
+ * Encodes a hex secret key as a NIP-19 `nsec` string.
+ */
 export function hexToNsec(privateKeyHex: string): string {
   const privateKeyBytes = hexToBytes(privateKeyHex)
   return nip19.nsecEncode(privateKeyBytes)
 }
 
+/**
+ * Decodes a NIP-19 `nsec` to a hex secret key.
+ *
+ * @throws {Error} `'Invalid nsec format'` when the bech32 prefix is not `nsec`.
+ */
 export function nsecToHex(nsec: string): string {
   const { type, data } = nip19.decode(nsec)
   if (type !== 'nsec') {
@@ -25,6 +39,7 @@ export function nsecToHex(nsec: string): string {
   return bytesToHex(data as Uint8Array)
 }
 
+/** True when `nsec` decodes as a NIP-19 nsec without throwing. */
 export function validateNsec(nsec: string): boolean {
   try {
     const { type } = nip19.decode(nsec)
@@ -34,14 +49,20 @@ export function validateNsec(nsec: string): boolean {
   }
 }
 
+/** True when `hex` is exactly 64 lowercase hex chars. */
 export function validateHexPrivateKey(hex: string): boolean {
   return /^[0-9a-f]{64}$/.test(hex)
 }
 
+/** True when `key` is either a valid nsec or a valid 64-char hex secret key. */
 export function validatePrivateKey(key: string): boolean {
   return validateNsec(key) || validateHexPrivateKey(key)
 }
 
+/**
+ * Normalises a secret key (hex or nsec) to lowercase hex.
+ * Assumes `key` already passed {@link validatePrivateKey}.
+ */
 export function privateKeyToHex(key: string): string {
   if (validateHexPrivateKey(key)) {
     return key
@@ -49,6 +70,13 @@ export function privateKeyToHex(key: string): string {
   return nsecToHex(key)
 }
 
+/**
+ * Parses a NIP-46 `bunker://` URL into its components.
+ *
+ * @returns Remote signer pubkey, the list of relays to use, and the optional
+ *   one-time secret used to authorise the initial connect.
+ * @throws {Error} `'Invalid bunker URL'` when the pubkey or relays are missing.
+ */
 export function parseBunkerUrl(url: string) {
   const u = new URL(url)
   const remoteUserPubkey = u.hostname // hex

--- a/apps/web/lib/ntag424.ts
+++ b/apps/web/lib/ntag424.ts
@@ -7,6 +7,13 @@ const debug = (message: string) => {
   console.info(message)
 }
 
+/**
+ * Builds the Boltcard "write" payload used to provision a blank NTAG424 with
+ * this card's keys and the LNURLW base pointing at our scan endpoint.
+ *
+ * @param card - Card record with its `ntag424` keys eagerly loaded.
+ * @param domain - The platform's public host (used in the `lnurlw://` URL).
+ */
 export function cardToNtag424WriteData(
   card: Card,
   domain: string
@@ -25,6 +32,10 @@ export function cardToNtag424WriteData(
   }
 }
 
+/**
+ * Builds the Boltcard "wipe" payload that resets an NTAG424 back to factory
+ * defaults using the card's recorded keys.
+ */
 export function cardToNtag424WipeData(card: Card): Ntag424WipeData {
   return {
     action: 'wipe',
@@ -38,7 +49,11 @@ export function cardToNtag424WipeData(card: Card): Ntag424WipeData {
   }
 }
 
-// Function to generate random ntag424 values
+/**
+ * Generates a fresh set of NTAG424 keys (k0–k4, 16 bytes each) and a zeroed
+ * tap counter for a given card UID. Keys are 128-bit AES keys returned as
+ * lowercase hex.
+ */
 export function generateNtag424Values(cid: string) {
   return {
     cid,
@@ -53,6 +68,10 @@ export function generateNtag424Values(cid: string) {
 
 /// *********** Ntag424 tap verification ***********
 
+/**
+ * Reasons a tap can be rejected during {@link consumeNtag424FromPC}. Surfaced
+ * to the caller via the `error` branch of the result; never thrown.
+ */
 export enum Ntag424Error {
   MALFORMED_P__NOT_A_32_CHAR_UPPERCASE_HEX_VALUE = 'Malformed p: not a 32-char uppercase hex value',
   MALFORMED_P__DOES_NOT_START_WITH_0XC7 = 'Malformed p: does not start with 0xC7',

--- a/apps/web/lib/prisma.ts
+++ b/apps/web/lib/prisma.ts
@@ -5,6 +5,11 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
+/**
+ * Singleton Prisma client. In dev/test we cache it on `globalThis` so Next.js
+ * hot reload doesn't open a new connection per module reload; production
+ * doesn't re-export so each instance gets its own client.
+ */
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({

--- a/apps/web/lib/public-url-utils.ts
+++ b/apps/web/lib/public-url-utils.ts
@@ -12,6 +12,10 @@ function isLocalHost(host: string): boolean {
   )
 }
 
+/**
+ * Joins a domain and optional subdomain into a single host string,
+ * lowercasing and trimming both. Returns `''` when `domain` is missing.
+ */
 export function buildPublicHost(domain?: string, subdomain?: string): string {
   const cleanDomain = normalizePart(domain)
   const cleanSubdomain = normalizePart(subdomain)
@@ -23,6 +27,10 @@ export function buildPublicHost(domain?: string, subdomain?: string): string {
   return cleanSubdomain ? `${cleanSubdomain}.${cleanDomain}` : cleanDomain
 }
 
+/**
+ * Wraps `host` in a scheme — `http://` for any localhost variant,
+ * `https://` otherwise. Returns `''` when `host` is missing.
+ */
 export function buildPublicUrl(host?: string): string {
   const cleanHost = normalizePart(host)
 

--- a/apps/web/lib/settings.ts
+++ b/apps/web/lib/settings.ts
@@ -1,5 +1,13 @@
 import { prisma } from '@/lib/prisma'
 
+/**
+ * Loads settings rows from the DB and returns them as a flat `name → value` object.
+ * Always pass `keys` when only a subset is needed — an unfiltered call scans the
+ * whole `Settings` table.
+ *
+ * @param keys - Optional whitelist of setting names to fetch.
+ * @returns Object keyed by setting name; missing keys are simply absent.
+ */
 export async function getSettings(keys?: string[]) {
   try {
     const settings = await prisma.settings.findMany({

--- a/apps/web/lib/setup/verify-token.ts
+++ b/apps/web/lib/setup/verify-token.ts
@@ -4,12 +4,23 @@ const TTL_MS = 5 * 60 * 1000
 
 let current: { token: string; expiresAt: number } | null = null
 
+/**
+ * Issues a fresh setup verification token and replaces any previous one.
+ * Single-slot by design — only one operator should be running first-time
+ * setup at a time.
+ *
+ * @returns A 48-char hex token, valid for {@link TTL_MS}.
+ */
 export function issueVerifyToken(): string {
   const token = randomBytes(24).toString('hex')
   current = { token, expiresAt: Date.now() + TTL_MS }
   return token
 }
 
+/**
+ * @returns The currently-issued setup token, or `null` if none has been issued
+ *   or the active one has expired (in which case it's also cleared).
+ */
 export function getVerifyToken(): string | null {
   if (!current) return null
   if (Date.now() > current.expiresAt) {

--- a/apps/web/lib/user.ts
+++ b/apps/web/lib/user.ts
@@ -4,6 +4,18 @@ import { prisma } from './prisma'
 import { getSettings } from './settings'
 import { ActivityEvent, logActivity } from './activity-log'
 
+/**
+ * Creates a brand-new `User` record for an authenticated pubkey, optionally
+ * provisioning an Alby Hub sub-account when `alby_auto_generate` is enabled
+ * and Alby credentials are configured.
+ *
+ * The returned shape mirrors what `findUnique` callers (notably
+ * `resolvePaymentRoute`) expect — the primary `LightningAddress` with its
+ * linked `nwcConnection`, plus the primary `NWCConnection` — so the union of
+ * "fresh signup" and "existing user" stays a single shape downstream.
+ *
+ * Also fires (best-effort, non-blocking) a `USER_SIGNUP` activity log entry.
+ */
 export async function createNewUser(pubkey: string) {
   const { alby_api_url, alby_bearer_token, alby_auto_generate } =
     await getSettings([

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,11 +1,18 @@
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
+/**
+ * shadcn/ui's class-name helper: combines `clsx` (conditional class lists) with
+ * `tailwind-merge` (resolves conflicting Tailwind utilities, last one wins).
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-// Helper to safely format date-like values
+/**
+ * Coerces any date-like input to a display string. Strings pass through
+ * unchanged so already-formatted server values aren't reformatted client-side.
+ */
 export function formatDate(value: string | number | Date | undefined): string {
   if (!value) return ''
   if (typeof value === 'string') return value
@@ -14,6 +21,10 @@ export function formatDate(value: string | number | Date | undefined): string {
   return String(value)
 }
 
+/**
+ * Generates `groups` random uppercase hex octets joined by `:` —
+ * e.g. `generateHexGroups(3)` → `"A1:B2:C3"`. Used to seed displayed card UIDs.
+ */
 export function generateHexGroups(groups: number): string {
   return Array.from({ length: groups }, () => {
     const hex = Math.floor(Math.random() * 256)

--- a/apps/web/lib/validation/middleware.ts
+++ b/apps/web/lib/validation/middleware.ts
@@ -1,6 +1,11 @@
 import { type ZodType, type ZodTypeDef } from 'zod'
 import { ValidationError } from '@/types/server/errors'
 
+/**
+ * Parses a JSON request body against a Zod schema and returns the typed result.
+ *
+ * @throws {ValidationError} On a parse failure; carries the Zod issue list as `details`.
+ */
 export async function validateBody<TOutput, TDef extends ZodTypeDef, TInput>(
   request: Request,
   schema: ZodType<TOutput, TDef, TInput>
@@ -13,6 +18,12 @@ export async function validateBody<TOutput, TDef extends ZodTypeDef, TInput>(
   return result.data
 }
 
+/**
+ * Validates query string parameters from a URL (or URL string) against a Zod schema.
+ * Repeated keys collapse to the last value because we materialise via `Object.fromEntries`.
+ *
+ * @throws {ValidationError} On a parse failure; carries the Zod issue list as `details`.
+ */
 export function validateQuery<TOutput, TDef extends ZodTypeDef, TInput>(
   url: URL | string,
   schema: ZodType<TOutput, TDef, TInput>
@@ -26,6 +37,12 @@ export function validateQuery<TOutput, TDef extends ZodTypeDef, TInput>(
   return result.data
 }
 
+/**
+ * Validates a Next.js App Router `params` object against a Zod schema.
+ * Callers should `await` the route's `params` promise before passing it in.
+ *
+ * @throws {ValidationError} On a parse failure; carries the Zod issue list as `details`.
+ */
 export function validateParams<TOutput, TDef extends ZodTypeDef, TInput>(
   params: Record<string, string>,
   schema: ZodType<TOutput, TDef, TInput>


### PR DESCRIPTION
## Summary

- Adds tight, tooling-focused JSDoc (`@param`/`@returns`/`@throws` + short WHY notes) to the previously-undocumented public exports across `apps/web/lib/`.
- Covers: auth (permissions, resolve-role, unified-auth), security boundaries (jwt, nip98), middleware/validation, server utilities (settings, user, logger, prisma, activity-log, albyhub, ntag424, nostr, utils, public-url-utils, events, setup), and a few client-side gaps (contacts-store, currencies-store, use-activity, nfc-card-id).
- Style choice — tooling-only comments that show up in IDE tooltips, no narrative prose. Honors the project's [CLAUDE.md](CLAUDE.md) rule against comments that restate what well-named identifiers already say.

## Why

Refs [#126](https://github.com/lawalletio/lawallet-nwc/issues/126) (epic [#136](https://github.com/lawalletio/lawallet-nwc/issues/136)). Public functions across `lib/` had inconsistent JSDoc coverage — some files were thoroughly documented, others (notably `lib/auth/permissions.ts`, `lib/jwt.ts`, `lib/settings.ts`, `lib/nostr.ts`) had none. This PR fills those gaps so IDE hover and downstream tools (SDK gen, OpenAPI) have signal to work with.

## Scope notes for the reviewer

**Skipped (deliberately):**
- `app/api/**/*.ts` route handlers — these are thin wrappers around the now-documented helpers (`withAuth`, `withErrorHandling`, etc.). Documenting them at the HTTP surface is what [#127](https://github.com/lawalletio/lawallet-nwc/issues/127) (OpenAPI/Swagger) is the right vehicle for. Suggest deciding whether to keep [#126](https://github.com/lawalletio/lawallet-nwc/issues/126) open for an `app/api/` follow-up or close once OpenAPI lands.
- `lib/client/cache/*`, `lib/client/nwc/*`, most files in `lib/client/hooks/`, `lib/wallet/*`, `lib/lnurl-probe.ts`, `lib/invoice-utils.ts`, `lib/ln-address.ts`, `lib/config/*`, `lib/admin-auth.ts`, `lib/jwt-auth.ts` — already well-documented per spot checks.

**Style:**
- One short prose line max where the WHY isn't obvious from the name.
- `@param` / `@returns` / `@throws` for IDE tooltips.
- No multi-paragraph docstrings (per [CLAUDE.md](CLAUDE.md)).
- No narrative comments restating what code does.

## Test plan

- [x] `pnpm --filter @lawallet-nwc/web test` — 585/585 pass across 50 files.
- [x] No runtime changes; pure JSDoc additions.
- [ ] Reviewer: hover a few exported functions in your editor (e.g. `hasRole`, `validateBody`, `verifyJwtToken`, `parseBunkerUrl`) and confirm the tooltips render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)